### PR TITLE
Add boxpdf library to PDF tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ Anything that's used to edit an existing PDF file:
 * [pdfcpu](https://github.com/pdfcpu/pdfcpu) ![](https://shields.io/badge/-extract-inactive)  ![](https://shields.io/badge/-manipulate-inactive) ![](https://shields.io/badge/-create-inactive): batch processing and scripting via a rich command line
 * [pdf-lib](https://github.com/Hopding/pdf-lib)  ![](https://shields.io/badge/-manipulate-inactive) ![](https://shields.io/badge/-create-inactive): Create and modify PDF documents in any JavaScript environment
 * [HexaPDF](https://hexapdf.gettalong.org): ![](https://shields.io/badge/-extract-inactive) ![](https://shields.io/badge/-manipulate-inactive) ![](https://shields.io/badge/-create-inactive): A pure Ruby PDF creation and manipulation library
+* [boxpdf](https://github.com/earonesty/boxpdf)  ![](https://shields.io/badge/-create-inactive): Flexbox DSL to generate server-side PDFs in any JS runtime.


### PR DESCRIPTION
Flexbox dsl is really needed to do nice pdf layouts.  Also boxpdf can "stream-render pages", meaning you can render a 1000 page pdf in 100k of RAM.  Both of which are needed for edge function use.

Without flexbox, you're forced to use coordinate math to do page layouts or use react renderer which drags in multi-mb libs and deps.  
